### PR TITLE
Add pid_suffix to .imap_notifier config to allow multiple notifiers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Example ~/.imap_notifier file
     server: 'imap.server.com'
     password: "1H@t3BuG$!"
     max: 10
+    ignore_exit_code: true  #defaults to false. When true, returns 0 instead of 1 on existing pidfile exit
 
 
 For Keychain Access support, specify the keychain item name and account in .imap_notifier.  The item must be designated an 'Internet password' in Keychain Access.

--- a/bin/imap_notifier
+++ b/bin/imap_notifier
@@ -6,6 +6,29 @@ require 'optparse'
 
 opts = {}
 
+def get_pid_suffix(suffix)
+  return if suffix.nil?
+  return PIDFILE.sub(/\.pid/,"_#{suffix}.pid")
+end
+
+def ensure_perms file
+  m =  sprintf("%o", File.stat(file).mode).split('').last(3).join().to_i
+  return if m.eql? 600
+  warn "#{file} permissions should be set to 600 #{m}"
+  exit 1
+end
+
+def read_conf opts
+  config = opts[:config] || "~/.imap_notifier"
+  file = File.expand_path(config)
+  return if ! File.exists? file
+  ensure_perms file
+  YAML.load(File.open(file)).each do |k,v|
+    opts[k.to_sym] ||= v
+  end
+  opts[:user] ||= ENV['USER']
+end
+
 opt_parser = OptionParser.new do |opt|
   opt.banner   = "Usage: #{opt.program_name} [OPTIONS]"
   opt.program_name = "IMAP Notifier"
@@ -52,10 +75,14 @@ opt_parser = OptionParser.new do |opt|
 end
 
 opt_parser.parse!
+read_conf opts
+@pid_file = get_pid_suffix(opts[:pid_suffix]) || PIDFILE
 
-if File.exists?(PIDFILE) && IO.readlines(PIDFILE).any?
-  puts "#{PIDFILE} already exists -- Exiting..."
-  exit -1
+if File.exists?(@pid_file) && IO.readlines(@pid_file).any?
+  puts "#{@pid_file} already exists -- Exiting..."
+  exit 0
 end
+
+
 
 IMAP_Notifier.new(opts)

--- a/bin/imap_notifier
+++ b/bin/imap_notifier
@@ -6,29 +6,6 @@ require 'optparse'
 
 opts = {}
 
-def get_pid_suffix(suffix)
-  return if suffix.nil?
-  return PIDFILE.sub(/\.pid/,"_#{suffix}.pid")
-end
-
-def ensure_perms file
-  m =  sprintf("%o", File.stat(file).mode).split('').last(3).join().to_i
-  return if m.eql? 600
-  warn "#{file} permissions should be set to 600 #{m}"
-  exit 1
-end
-
-def read_conf opts
-  config = opts[:config] || "~/.imap_notifier"
-  file = File.expand_path(config)
-  return if ! File.exists? file
-  ensure_perms file
-  YAML.load(File.open(file)).each do |k,v|
-    opts[k.to_sym] ||= v
-  end
-  opts[:user] ||= ENV['USER']
-end
-
 opt_parser = OptionParser.new do |opt|
   opt.banner   = "Usage: #{opt.program_name} [OPTIONS]"
   opt.program_name = "IMAP Notifier"
@@ -75,14 +52,4 @@ opt_parser = OptionParser.new do |opt|
 end
 
 opt_parser.parse!
-read_conf opts
-@pid_file = get_pid_suffix(opts[:pid_suffix]) || PIDFILE
-
-if File.exists?(@pid_file) && IO.readlines(@pid_file).any?
-  puts "#{@pid_file} already exists -- Exiting..."
-  exit 0
-end
-
-
-
 IMAP_Notifier.new(opts)

--- a/lib/imap_notifier/base.rb
+++ b/lib/imap_notifier/base.rb
@@ -29,6 +29,12 @@ class IMAP_Notifier
 
   def initialize(opts={})
     config opts
+
+    if File.exists?(@custom_pid) && IO.readlines(@custom_pid).any?
+      puts "#{@custom_pid} already exists -- Exiting..."
+      exit @ignore_exit_code ? 0 : 1
+    end
+
     @notifier = IMAP_Notifier::Alert.new
 
     pid = fork do

--- a/lib/imap_notifier/base.rb
+++ b/lib/imap_notifier/base.rb
@@ -1,20 +1,18 @@
 class IMAP_Notifier
   def self.kill_process
-    matchingPids = Dir['/tmp/imap_notifier*.pid']
-    pid = 0
-    pidFile = ""
-    if matchingPids.length > 1
+    matching_pids = Dir['/tmp/imap_notifier*.pid']
+    if matching_pids.length > 1
       prompts = ["[Q] Cancel"]
-      matchingPids.each_with_index do |pFile, i|
-        prompts.push("["+i.to_s+"] "+pFile)
+      matching_pids.each_with_index do |p_file, i|
+        prompts.push("[#{i}] #{p_file}")
       end
       pidIndex = ask("Select PID by number\n" + prompts.join("\n")) { |q|
-        q.validate = /^[0-#{matchingPids.length-1},q,Q]{1}$/
+        q.validate = /^[0-#{matching_pids.length-1},q,Q]{1}$/
       }
       return if pidIndex.downcase == "q"
       pidFile = Dir['/tmp/imap_notifier*.pid'][pidIndex.to_i]
     else
-      pidFile = Dir['/tmp/imap_notifier*.pid'][0]
+      pidFile = Dir['/tmp/imap_notifier*.pid'].first
     end
       pid = IO.readlines(pidFile).first.to_i
     puts "Killing PID: #{pid}"

--- a/lib/imap_notifier/config.rb
+++ b/lib/imap_notifier/config.rb
@@ -23,14 +23,8 @@ class IMAP_Notifier
 
   private
   def get_pid_suffix(suffix)
-    if suffix != nil
-      pidfile = ""
-      pidparts = PIDFILE.split(".")
-      pidparts.delete("pid")
-      pidparts.push(suffix)
-      return pidparts.join("_") + ".pid"
-    end
-    return nil      
+    return if suffix.nil?
+    return PIDFILE.sub(/\.pid/,"_#{suffix}.pid")
   end
 
   def get_password

--- a/lib/imap_notifier/config.rb
+++ b/lib/imap_notifier/config.rb
@@ -13,6 +13,7 @@ class IMAP_Notifier
     @folders     = mbox_conf opts[:folders] || ['INBOX']
     @debug       = opts[:debug] || false
     @max_mail    = opts[:max]   || MAX_MAIL
+    @custom_pid  = get_pid_suffix(opts[:pid_suffix]) || PIDFILE
   end
 
   private
@@ -21,6 +22,17 @@ class IMAP_Notifier
   end
 
   private
+  def get_pid_suffix(suffix)
+    if suffix != nil
+      pidfile = ""
+      pidparts = PIDFILE.split(".")
+      pidparts.delete("pid")
+      pidparts.push(suffix)
+      return pidparts.join("_") + ".pid"
+    end
+    return nil      
+  end
+
   def get_password
     if $key_name && $key_account
       key = %x{security find-internet-password -w -a #{$key_account} -s #{$key_name}}

--- a/lib/imap_notifier/config.rb
+++ b/lib/imap_notifier/config.rb
@@ -1,19 +1,20 @@
 class IMAP_Notifier
   def config(opts={})
     read_conf opts
-    @imap_server = opts[:server] || IMAP_SERVER
-    @domain      = opts[:domain] || @imap_server.split('.').pop(2).join('.')
-    @user        = "#{opts[:user]}@#{@domain}"
-    $key_name    = opts[:key_name] || false
-    $key_account = opts[:key_account] || false
-    $pass        = opts[:pass] || false
-    $one_path    = opts[:one_path] || false
-    $onepass     = opts[:onepass] || false
-    @password    = opts[:password] || get_password
-    @folders     = mbox_conf opts[:folders] || ['INBOX']
-    @debug       = opts[:debug] || false
-    @max_mail    = opts[:max]   || MAX_MAIL
-    @custom_pid  = get_pid_suffix(opts[:pid_suffix]) || PIDFILE
+    @imap_server      = opts[:server] || IMAP_SERVER
+    @domain           = opts[:domain] || @imap_server.split('.').pop(2).join('.')
+    @user             = "#{opts[:user]}@#{@domain}"
+    $key_name         = opts[:key_name] || false
+    $key_account      = opts[:key_account] || false
+    $pass             = opts[:pass] || false
+    $one_path         = opts[:one_path] || false
+    $onepass          = opts[:onepass] || false
+    @password         = opts[:password] || get_password
+    @folders          = mbox_conf opts[:folders] || ['INBOX']
+    @debug            = opts[:debug] || false
+    @max_mail         = opts[:max]   || MAX_MAIL
+    @ignore_exit_code = opts[:ignore_exit_code].to_s == 'true'
+    @custom_pid       = get_pid_suffix(opts[:pid_suffix]) || PIDFILE
   end
 
   private


### PR DESCRIPTION
Some users may have multiple emails, and this change allows them to
have a separate imap notifier for each of them, based on a suffix added
to the .pid file.
ex. pid_suffix = "gmail", creates /tmp/image_notifier_gmail.pid.
On `imap_notifier -k`, if multiple imap_notifiers exist, they are
listed so the user can select which one to kill.
